### PR TITLE
Drop support of Python3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -17,7 +17,7 @@ disable=
     too-many-instance-attributes, too-few-public-methods,
     redefined-builtin, broad-except, protected-access,
     useless-object-inheritance, unnecessary-pass, duplicate-code,
-    function-redefined, consider-using-f-string
+    function-redefined
 
 [REPORTS]
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ project family, whence its name.
 Requirements
 ============
 
-* Python_ >= 3.5
+* Python_ >= 3.6
 
 .. _Python: https://www.python.org
 

--- a/inators/arg/version_argument.py
+++ b/inators/arg/version_argument.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -30,4 +30,4 @@ def add_version_argument(
 
     add_argument(parser, short_alias, '--version', long_alias,
                  action='version',
-                 version='%(prog)s {version}'.format(version=version))
+                 version=f'%(prog)s {version}')

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -26,6 +25,6 @@ platform = any
 
 [options]
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     importlib-metadata; python_version < "3.8"

--- a/tests/arg/test_log_level_argument.py
+++ b/tests/arg/test_log_level_argument.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -45,6 +45,6 @@ def test_add_log_level_argument(func_args, func_kwargs, sys_argv, exp):
 ])
 def test_process_log_level_argument(level_name, exp_level_value):
     args = MockNamespace(log_level=level_name)
-    logger = logging.getLogger('{}.logger{}'.format(__name__, level_name))
+    logger = logging.getLogger(f'{__name__}.logger{level_name}')
     inators_arg.process_log_level_argument(args, logger)
     assert logger.getEffectiveLevel() == exp_level_value

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -33,7 +33,7 @@ def test_level_names(level, value):
     (inators_log.DISABLE, logging.CRITICAL, False),
 ])
 def test_level_values(logger_level, msg_level, enabled):
-    logger = logging.getLogger('{}.logger{}'.format(__name__, logger_level))
+    logger = logging.getLogger(f'{__name__}.logger{logger_level}')
     logger.setLevel(logger_level)
     assert logger.isEnabledFor(msg_level) == enabled
 
@@ -44,7 +44,7 @@ def test_level_values(logger_level, msg_level, enabled):
     (inators_log.DISABLE, u'baz', u''),
 ])
 def test_trace(logger_level, msg, output):
-    logger = inators_log.getLogger('{}.trace'.format(__name__))
+    logger = inators_log.getLogger(f'{__name__}.trace')
     logger.setLevel(logger_level)
     stream = io.StringIO()
     logger.addHandler(logging.StreamHandler(stream=stream))


### PR DESCRIPTION
Python3.5 has reached the end of its lifetime two years ago, hence Inators also stops supporting it. The patch introduces the usage of f-strings - supported from Python3.6 - and unifies string representations to use it where possible.
It also enables the 'consider-using-f-string' pylint checker.