### PR TITLE
Fix pylint issue

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,7 @@
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
+    useless-option-value,
     line-too-long, fixme, missing-docstring, invalid-name, no-self-use, unused-argument,
     wildcard-import, unused-wildcard-import, ungrouped-imports,
     too-many-arguments, too-many-locals,


### PR DESCRIPTION
The `no-self-use` warning had to be disabled previously for pylint. But recent pylint does not check for it anymore, and so listing it as disabled causes a warning. As both older and newer pylint versions are to be supported, the new warning is also disabled.