### PR TITLE
Drop support of Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.9']
-        exclude:
-          - python-version: 3.6
-            os: ubuntu-latest
-        include:
-          - python-version: 3.6
-            os: ubuntu-20.04
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.9']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ project family, whence its name.
 Requirements
 ============
 
-* Python_ >= 3.6
+* Python_ >= 3.7
 
 .. _Python: https://www.python.org
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,6 +24,6 @@ platform = any
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     importlib-metadata; python_version < "3.8"


### PR DESCRIPTION
Python 3.6 has reached the end of its lifetime more than a year ago.