### PR TITLE
Ensure test quality via linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,6 +16,7 @@ disable=
     missing-docstring,
     no-self-use,  # disables warning in older pylint
     redefined-builtin,
+    too-few-public-methods,
     too-many-arguments,
     unused-argument,
     unused-wildcard-import,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/arg/__init__.py
+++ b/tests/arg/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/arg/common_arg.py
+++ b/tests/arg/common_arg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -36,7 +36,7 @@ def _test_add_argument(add_argument_func, func_args, func_kwargs, sys_argv, exp)
             assert getattr(args, key) == value
 
 
-class MockNamespace(object):
+class MockNamespace:
 
     def __init__(self, **kwargs):
         for name, value in kwargs.items():

--- a/tests/arg/test_add_argument.py
+++ b/tests/arg/test_add_argument.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 from inators import arg as inators_arg
 
-from common_arg import _test_add_argument
+from .common_arg import _test_add_argument
 
 
 @pytest.mark.parametrize('func_args, func_kwargs, sys_argv, exp', [

--- a/tests/arg/test_log_level_argument.py
+++ b/tests/arg/test_log_level_argument.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -11,7 +11,7 @@ import pytest
 from inators import arg as inators_arg
 from inators import log as inators_log
 
-from common_arg import _test_add_argument, MockArgumentParserError, MockNamespace
+from .common_arg import _test_add_argument, MockArgumentParserError, MockNamespace
 
 
 @pytest.mark.parametrize('func_args, func_kwargs, sys_argv, exp', [

--- a/tests/arg/test_sys_path_argument.py
+++ b/tests/arg/test_sys_path_argument.py
@@ -1,16 +1,17 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import pytest
 import sys
+
+import pytest
 
 from inators import arg as inators_arg
 
-from common_arg import _test_add_argument, MockNamespace
+from .common_arg import _test_add_argument, MockNamespace
 
 
 @pytest.mark.parametrize('func_args, func_kwargs, sys_argv, exp', [

--- a/tests/arg/test_sys_recursion_limit_argument.py
+++ b/tests/arg/test_sys_recursion_limit_argument.py
@@ -1,16 +1,17 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import pytest
 import sys
+
+import pytest
 
 from inators import arg as inators_arg
 
-from common_arg import _test_add_argument, MockArgumentParserError, MockNamespace
+from .common_arg import _test_add_argument, MockArgumentParserError, MockNamespace
 
 
 @pytest.mark.parametrize('func_args, func_kwargs, sys_argv, exp', [

--- a/tests/arg/test_version_argument.py
+++ b/tests/arg/test_version_argument.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 from inators import arg as inators_arg
 
-from common_arg import _test_add_argument, MockArgumentParserExit
+from .common_arg import _test_add_argument, MockArgumentParserExit
 
 
 @pytest.mark.parametrize('func_args, func_kwargs, sys_argv, exp', [

--- a/tests/sphinx/__init__.py
+++ b/tests/sphinx/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/sphinx/test_argdoc.py
+++ b/tests/sphinx/test_argdoc.py
@@ -1,12 +1,13 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import pytest
 import textwrap
+
+import pytest
 
 from inators import sphinx as inators_sphinx
 
@@ -17,6 +18,7 @@ def add_foo_argument(parser):
     .. argdoc
     '''
     parser.add_argument('--foo', help='foo argument')
+
 
 add_foo_argument.argdoc = [
     '''
@@ -47,12 +49,14 @@ add_foo_argument.argdoc = [
     ''',
 ]
 
+
 def add_bar_argument(parser, *, bar):
     '''
     Add ``--bar`` command-line argument to ``parser``.
     .. argdoc {'bar': 42}
     '''
     parser.add_argument('--bar', default=bar, help='bar argument (default: %(default)s)')
+
 
 add_bar_argument.argdoc = [
     '''

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -39,9 +39,9 @@ def test_level_values(logger_level, msg_level, enabled):
 
 
 @pytest.mark.parametrize('logger_level, msg, output', [
-    (inators_log.TRACE, u'foo', u'foo\n'),
-    (inators_log.DEBUG, u'bar', u''),
-    (inators_log.DISABLE, u'baz', u''),
+    (inators_log.TRACE, 'foo', 'foo\n'),
+    (inators_log.DEBUG, 'bar', ''),
+    (inators_log.DISABLE, 'baz', ''),
 ])
 def test_trace(logger_level, msg, output):
     logger = inators_log.getLogger(f'{__name__}.trace')

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ usedevelop = true
 deps =
     pycodestyle
     pylint
+    pytest
 commands =
-    pylint src/inators
-    pycodestyle src/inators --ignore=E501
+    pylint src/inators tests
+    pycodestyle src/inators tests --ignore=E501
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
- Change test folders to packages to allow relative imports.
- List standard modules first in imports.
- Don't specify object as superclass.
- Avoid u string-prefix.
- Use double blank lines to separate top-level elements.