### PR TITLE
Don't import importlib_metadata since Py3.8 already has it as importlib.metadata

### DIFF
--- a/src/inators/pkgdata.py
+++ b/src/inators/pkgdata.py
@@ -1,14 +1,11 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2024 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
+from importlib import metadata
 
 
 __version__ = metadata.version(__package__)


### PR DESCRIPTION
It has already been dropped from setup.cfg.