### PR TITLE
Improve the rendering of `.. argdoc`

### DIFF
--- a/src/inators/sphinx/argdoc.py
+++ b/src/inators/sphinx/argdoc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2025 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -62,10 +62,10 @@ def argdoc(app, what, name, obj, options, lines):
             obj(parser, **kwargs)
             replacement = textwrap.dedent("""
 
-                Command-line interface
-                    .. code-block:: none
+            .. rubric:: Command-line Interface:
+            .. code-block:: none
 
-            """) + textwrap.indent(parser.format_help(), ' ' * 8)
+            """) + textwrap.indent(parser.format_help(), ' ' * 4)
             replacement = textwrap.indent(replacement, indent).splitlines()
             lines[i:i + 1] = replacement[:]
             break

--- a/tests/sphinx/test_argdoc.py
+++ b/tests/sphinx/test_argdoc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2025 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -24,27 +24,25 @@ add_foo_argument.argdoc = [
     '''
     Add ``--foo`` command-line argument to ``parser``.
 
+    .. rubric:: Command-line Interface:
+    .. code-block:: none
 
-    Command-line interface
-        .. code-block:: none
+        usage: [--foo FOO]
 
-            usage: [--foo FOO]
-
-            optional arguments:
-              --foo FOO  foo argument
+        optional arguments:
+          --foo FOO  foo argument
 
     ''',
     '''
     Add ``--foo`` command-line argument to ``parser``.
 
+    .. rubric:: Command-line Interface:
+    .. code-block:: none
 
-    Command-line interface
-        .. code-block:: none
+        usage: [--foo FOO]
 
-            usage: [--foo FOO]
-
-            options:
-              --foo FOO  foo argument
+        options:
+          --foo FOO  foo argument
 
     ''',
 ]
@@ -62,27 +60,25 @@ add_bar_argument.argdoc = [
     '''
     Add ``--bar`` command-line argument to ``parser``.
 
+    .. rubric:: Command-line Interface:
+    .. code-block:: none
 
-    Command-line interface
-        .. code-block:: none
+        usage: [--bar BAR]
 
-            usage: [--bar BAR]
-
-            optional arguments:
-              --bar BAR  bar argument (default: 42)
+        optional arguments:
+          --bar BAR  bar argument (default: 42)
 
     ''',
     '''
     Add ``--bar`` command-line argument to ``parser``.
 
+    .. rubric:: Command-line Interface:
+    .. code-block:: none
 
-    Command-line interface
-        .. code-block:: none
+        usage: [--bar BAR]
 
-            usage: [--bar BAR]
-
-            options:
-              --bar BAR  bar argument (default: 42)
+        options:
+          --bar BAR  bar argument (default: 42)
 
     ''',
 ]


### PR DESCRIPTION
Instead of rendering a plain text "Command-line interface" above the argument parser's help message, a proper heading is rendered with the help of a `.. rubric::` directive. This makes a nicer visual integration with the rest of the documentation.