### PR TITLE
Update Python support: drop 3.9, add 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Utilities
 platform = any
 


### PR DESCRIPTION
Python 3.14 has been released, while 3.9 reached its end of life.